### PR TITLE
SlackElements(Block elements)の追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Kin29\\SlackBlocksBuilder\\": "tests/"
+            "Kin29\\SlackBlocksBuilder\\Tests\\": "tests/"
         }
     },
     "require-dev": {

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -11,7 +11,6 @@
     <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
     <rule ref="rulesets/codesize.xml/ExcessiveParameterList"/>
     <rule ref="rulesets/codesize.xml/ExcessivePublicCount"/>
-    <rule ref="rulesets/codesize.xml/TooManyFields"/>
     <rule ref="rulesets/codesize.xml/TooManyMethods"/>
     <!--design-->
     <rule ref="rulesets/design.xml/EvalExpression"/>

--- a/src/Message/SlackBlock.php
+++ b/src/Message/SlackBlock.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Kin29\SlackBlocksBuilder\Message;
 
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackElement;
+
 class SlackBlock extends AbstractSlackMessage
 {
     /**
@@ -66,6 +68,12 @@ class SlackBlock extends AbstractSlackMessage
     protected array $label;
 
     /**
+     * @var array
+     * type="input"の時必須
+     */
+    protected array $element;
+
+    /**
      * @var bool
      */
     protected bool $dispatch_action = false;
@@ -109,7 +117,7 @@ class SlackBlock extends AbstractSlackMessage
     {
         foreach ($elements as $element) {
             if (!$element instanceof SlackElement) {
-                throw new \LogicException('Must hold only SlackBlock instances.');
+                throw new \LogicException('Must hold only SlackElement instances.');
             }
 
             $this->elements[] = $element->payload();
@@ -195,6 +203,16 @@ class SlackBlock extends AbstractSlackMessage
     public function label(SlackText $label): SlackBlock
     {
         $this->label = $label->payload();
+        return $this;
+    }
+
+    /**
+     * @param SlackElement $element
+     * @return SlackBlock
+     */
+    public function element(SlackElement $element): SlackBlock
+    {
+        $this->element = $element->payload();
         return $this;
     }
 

--- a/src/Message/SlackBlock.php
+++ b/src/Message/SlackBlock.php
@@ -254,7 +254,7 @@ class SlackBlock extends AbstractSlackMessage
     {
         foreach ($fields as $field) {
             if (!$field instanceof SlackText) {
-                throw new \LogicException('Must hold only SlackBlock instances.');
+                throw new \LogicException('Must hold only SlackText instances.');
             }
 
             $this->fields[] = $field->payload();

--- a/src/Message/SlackConfirm.php
+++ b/src/Message/SlackConfirm.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message;
+
+class SlackConfirm extends AbstractSlackMessage
+{
+    protected array $title;
+    protected array $text;
+    protected array $confirm;
+    protected array $deny;
+    protected string $style;
+
+    /**
+     * @param SlackText $title
+     * @return SlackConfirm
+     */
+    public function title(SlackText $title): SlackConfirm
+    {
+        $this->title = $title->payload();
+        return $this;
+    }
+
+    /**
+     * @param SlackText $text
+     * @return SlackConfirm
+     */
+    public function text(SlackText $text): SlackConfirm
+    {
+        $this->text = $text->payload();
+        return $this;
+    }
+
+    /**
+     * @param SlackText $confirm
+     * @return SlackConfirm
+     */
+    public function confirm(SlackText $confirm): SlackConfirm
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+
+    /**
+     * @param SlackText $deny
+     * @return SlackConfirm
+     */
+    public function deny(SlackText $deny): SlackConfirm
+    {
+        $this->deny = $deny->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $style
+     * @return SlackConfirm
+     */
+    public function style(string $style): SlackConfirm
+    {
+        $this->style = $style;
+        return $this;
+    }
+}

--- a/src/Message/SlackDispatchActionConfiguration.php
+++ b/src/Message/SlackDispatchActionConfiguration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message;
+
+class SlackDispatchActionConfiguration extends AbstractSlackMessage
+{
+    /**
+     * @var string[] "on_enter_pressed","on_character_entered"
+     */
+    protected array $trigger_actions_on;
+}

--- a/src/Message/SlackElement/SlackButtonElement.php
+++ b/src/Message/SlackElement/SlackButtonElement.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+
+class SlackButtonElement extends SlackElement
+{
+    protected ?string $type = 'button';
+
+    protected array $text;
+
+    protected string $action_id;
+
+    protected string $url;
+
+    protected string $value;
+
+    protected string $style;
+
+    protected array $confirm;
+
+    /**
+     * @param SlackText $text
+     * @return SlackButtonElement
+     */
+    public function text(SlackText $text): SlackButtonElement
+    {
+        $this->text = $text->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $action_id
+     * @return SlackButtonElement
+     */
+    public function actionId(string $action_id): SlackButtonElement
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param string $url
+     * @return SlackButtonElement
+     */
+    public function url(string $url): SlackButtonElement
+    {
+        $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * @param string $value
+     * @return SlackButtonElement
+     */
+    public function value(string $value): SlackButtonElement
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * @param string $style
+     * @return SlackButtonElement
+     */
+    public function style(string $style): SlackButtonElement
+    {
+        $this->style = $style;
+        return $this;
+    }
+
+    /**
+     * @param SlackConfirm $confirm
+     * @return SlackButtonElement
+     */
+    public function confirm(SlackConfirm $confirm): SlackButtonElement
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackCheckBoxGroups.php
+++ b/src/Message/SlackElement/SlackCheckBoxGroups.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackMessageInterface;
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+
+class SlackCheckBoxGroups extends SlackElement
+{
+    protected ?string $type = 'checkboxes';
+
+    protected string $action_id;
+
+    protected array $options;
+
+    protected array $initial_options;
+
+    protected array $confirm;
+
+    /**
+     * @param string $action_id
+     * @return SlackCheckBoxGroups
+     */
+    public function actionId(string $action_id): SlackCheckBoxGroups
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param SlackOption[] $options
+     * @return SlackMessageInterface
+     */
+    public function options(array $options): SlackMessageInterface
+    {
+        foreach ($options as $option) {
+            if (!$option instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->options[] = $option->payload();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param SlackOption[] $initialOptions
+     * @return SlackMessageInterface
+     */
+    public function initialOptions(array $initialOptions): SlackMessageInterface
+    {
+        foreach ($initialOptions as $initialOption) {
+            if (!$initialOption instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->initial_options[] = $initialOption->payload();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param SlackConfirm $confirm
+     * @return SlackCheckBoxGroups
+     */
+    public function confirm(SlackConfirm $confirm): SlackCheckBoxGroups
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackCheckBoxGroups.php
+++ b/src/Message/SlackElement/SlackCheckBoxGroups.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
 
 use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
-use Kin29\SlackBlocksBuilder\Message\SlackMessageInterface;
 use Kin29\SlackBlocksBuilder\Message\SlackOption;
 
 class SlackCheckBoxGroups extends SlackElement
@@ -32,9 +31,9 @@ class SlackCheckBoxGroups extends SlackElement
 
     /**
      * @param SlackOption[] $options
-     * @return SlackMessageInterface
+     * @return SlackCheckBoxGroups
      */
-    public function options(array $options): SlackMessageInterface
+    public function options(array $options): SlackCheckBoxGroups
     {
         foreach ($options as $option) {
             if (!$option instanceof SlackOption) {
@@ -49,9 +48,9 @@ class SlackCheckBoxGroups extends SlackElement
 
     /**
      * @param SlackOption[] $initialOptions
-     * @return SlackMessageInterface
+     * @return SlackCheckBoxGroups
      */
-    public function initialOptions(array $initialOptions): SlackMessageInterface
+    public function initialOptions(array $initialOptions): SlackCheckBoxGroups
     {
         foreach ($initialOptions as $initialOption) {
             if (!$initialOption instanceof SlackOption) {

--- a/src/Message/SlackElement/SlackDatePickerElement.php
+++ b/src/Message/SlackElement/SlackDatePickerElement.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+
+class SlackDatePickerElement extends SlackElement
+{
+    protected ?string $type = 'datepicker';
+
+    protected string $action_id;
+
+    protected array $placeholder;
+
+    protected string $initial_date;
+
+    protected array $confirm;
+
+    /**
+     * @param string $action_id
+     * @return SlackDatePickerElement
+     */
+    public function actionId(string $action_id): SlackDatePickerElement
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param SlackText $placeholder
+     * @return SlackDatePickerElement
+     */
+    public function placeholder(SlackText $placeholder): SlackDatePickerElement
+    {
+        $this->placeholder = $placeholder->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $initial_date
+     * @return SlackDatePickerElement
+     */
+    public function initialDate(string $initial_date): SlackDatePickerElement
+    {
+        $this->initial_date = $initial_date;
+        return $this;
+    }
+
+    /**
+     * @param SlackConfirm $confirm
+     * @return SlackDatePickerElement
+     */
+    public function confirm(SlackConfirm $confirm): SlackDatePickerElement
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackElement.php
+++ b/src/Message/SlackElement/SlackElement.php
@@ -11,25 +11,6 @@ class SlackElement extends AbstractSlackMessage
 {
     protected ?string $type = null;
 
-    protected array $elements;
-
-    /**
-     * @param SlackElement[] $elements
-     * @return SlackMessageInterface
-     */
-    public function elements(array $elements): SlackMessageInterface
-    {
-        foreach ($elements as $element) {
-            if (!$element instanceof SlackElement) {
-                throw new \LogicException('Must hold only SlackBlock instances.');
-            }
-
-            $this->elements[] = $element->payload();
-        }
-
-        return $this;
-    }
-
     public function type(): SlackElement
     {
         return $this;

--- a/src/Message/SlackElement/SlackElement.php
+++ b/src/Message/SlackElement/SlackElement.php
@@ -2,10 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Kin29\SlackBlocksBuilder\Message;
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\AbstractSlackMessage;
+use Kin29\SlackBlocksBuilder\Message\SlackMessageInterface;
 
 class SlackElement extends AbstractSlackMessage
 {
+    protected ?string $type = null;
+
     protected array $elements;
 
     /**
@@ -22,6 +27,11 @@ class SlackElement extends AbstractSlackMessage
             $this->elements[] = $element->payload();
         }
 
+        return $this;
+    }
+
+    public function type(): SlackElement
+    {
         return $this;
     }
 }

--- a/src/Message/SlackElement/SlackImageElement.php
+++ b/src/Message/SlackElement/SlackImageElement.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+class SlackImageElement extends SlackElement
+{
+    protected ?string $type = 'image';
+
+    protected string $image_url;
+
+    protected string $alt_text;
+
+    /**
+     * @param string $image_url
+     * @return SlackImageElement
+     */
+    public function imageUrl(string $image_url): SlackImageElement
+    {
+        $this->image_url = $image_url;
+        return $this;
+    }
+
+    /**
+     * @param string $alt_text
+     * @return SlackImageElement
+     */
+    public function altText(string $alt_text): SlackImageElement
+    {
+        $this->alt_text = $alt_text;
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiConversationsList.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiConversationsList.php
@@ -6,7 +6,7 @@ namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElem
 
 use Kin29\SlackBlocksBuilder\Message\SlackFilter;
 
-class SlackMultiConversationsList extends SlackSelectMenuElement
+class SlackMultiConversationsList extends SlackMultiSelectMenuElement
 {
     protected ?string $type = 'multi_conversations_select';
 

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiConversationsList.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiConversationsList.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackFilter;
+
+class SlackMultiConversationsList extends SlackSelectMenuElement
+{
+    protected ?string $type = 'multi_conversations_select';
+
+    /**
+     * @var string[]
+     */
+    protected array $initial_conversations;
+
+    protected bool $default_to_current_conversation = false;
+
+    protected array $filter;
+
+
+    /**
+     * @param string[] $initial_conversations
+     * @return SlackMultiConversationsList
+     */
+    public function initialConversations(array $initial_conversations): SlackMultiConversationsList
+    {
+        $this->initial_conversations = $initial_conversations;
+        return $this;
+    }
+
+    /**
+     * @param bool $default_to_current_conversation
+     * @return SlackMultiConversationsList
+     */
+    public function defaultToCurrentConversation(bool $default_to_current_conversation): SlackMultiConversationsList
+    {
+        $this->default_to_current_conversation = $default_to_current_conversation;
+        return $this;
+    }
+
+    /**
+     * @param SlackFilter $filter
+     * @return SlackMultiConversationsList
+     */
+    public function filter(SlackFilter $filter): SlackMultiConversationsList
+    {
+        $this->filter = $filter->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiExternalSelect.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiExternalSelect.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+
+class SlackMultiExternalSelect extends SlackSelectMenuElement
+{
+    protected ?string $type = 'multi_external_select';
+
+    protected int $min_query_length;
+
+    /**
+     * @param int $min_query_length
+     * @return SlackMultiExternalSelect
+     */
+    public function minQueryLength(int $min_query_length): SlackMultiExternalSelect
+    {
+        $this->min_query_length = $min_query_length;
+        return $this;
+    }
+
+    protected array $initial_options;
+
+    /**
+     * @param SlackOption[] $initialOptions
+     * @return SlackMultiExternalSelect
+     */
+    public function initialOptions(array $initialOptions): SlackMultiExternalSelect
+    {
+        foreach ($initialOptions as $initialOption) {
+            if (!$initialOption instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->initial_options[] = $initialOption->payload();
+        }
+
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiExternalSelect.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiExternalSelect.php
@@ -6,7 +6,7 @@ namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElem
 
 use Kin29\SlackBlocksBuilder\Message\SlackOption;
 
-class SlackMultiExternalSelect extends SlackSelectMenuElement
+class SlackMultiExternalSelect extends SlackMultiSelectMenuElement
 {
     protected ?string $type = 'multi_external_select';
 

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiPublicChannelsList.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiPublicChannelsList.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement;
 
-use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
-use Kin29\SlackBlocksBuilder\Message\SlackText;
-
-class SlackMultiPublicChannelsList extends SlackSelectMenuElement
+class SlackMultiPublicChannelsList extends SlackMultiSelectMenuElement
 {
     protected ?string $type = 'multi_channels_select';
 

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiPublicChannelsList.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiPublicChannelsList.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+
+class SlackMultiPublicChannelsList extends SlackSelectMenuElement
+{
+    protected ?string $type = 'multi_channels_select';
+
+    /**
+     * @var string[]
+     */
+    protected array $initial_channels;
+
+    /**
+     * @param string[] $initial_channels
+     * @return SlackMultiPublicChannelsList
+     */
+    public function initialChannels(array $initial_channels): SlackMultiPublicChannelsList
+    {
+        $this->initial_channels = $initial_channels;
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiSelectMenuElement.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiSelectMenuElement.php
@@ -20,9 +20,9 @@ class SlackMultiSelectMenuElement extends SlackElement
 
     /**
      * @param SlackText $placeholder
-     * @return SlackSelectMenuElement
+     * @return SlackMultiSelectMenuElement
      */
-    public function placeholder(SlackText $placeholder): SlackSelectMenuElement
+    public function placeholder(SlackText $placeholder): SlackMultiSelectMenuElement
     {
         $this->placeholder = $placeholder->payload();
         return $this;
@@ -30,9 +30,9 @@ class SlackMultiSelectMenuElement extends SlackElement
 
     /**
      * @param string $action_id
-     * @return SlackSelectMenuElement
+     * @return SlackMultiSelectMenuElement
      */
-    public function actionId(string $action_id): SlackSelectMenuElement
+    public function actionId(string $action_id): SlackMultiSelectMenuElement
     {
         $this->action_id = $action_id;
         return $this;
@@ -40,9 +40,9 @@ class SlackMultiSelectMenuElement extends SlackElement
 
     /**
      * @param SlackConfirm $confirm
-     * @return SlackSelectMenuElement
+     * @return SlackMultiSelectMenuElement
      */
-    public function confirm(SlackConfirm $confirm): SlackSelectMenuElement
+    public function confirm(SlackConfirm $confirm): SlackMultiSelectMenuElement
     {
         $this->confirm = $confirm->payload();
         return $this;
@@ -50,9 +50,9 @@ class SlackMultiSelectMenuElement extends SlackElement
 
     /**
      * @param int $max_selected_items
-     * @return SlackSelectMenuElement
+     * @return SlackMultiSelectMenuElement
      */
-    public function maxSelectedItems(int $max_selected_items): SlackSelectMenuElement
+    public function maxSelectedItems(int $max_selected_items): SlackMultiSelectMenuElement
     {
         $this->max_selected_items = $max_selected_items;
         return $this;

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiSelectMenuElement.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiSelectMenuElement.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackElement;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+
+class SlackMultiSelectMenuElement extends SlackElement
+{
+    protected array $placeholder;
+
+    protected string $action_id;
+
+    protected array $confirm;
+
+    protected int $max_selected_items;
+
+    /**
+     * @param SlackText $placeholder
+     * @return SlackSelectMenuElement
+     */
+    public function placeholder(SlackText $placeholder): SlackSelectMenuElement
+    {
+        $this->placeholder = $placeholder->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $action_id
+     * @return SlackSelectMenuElement
+     */
+    public function actionId(string $action_id): SlackSelectMenuElement
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param SlackConfirm $confirm
+     * @return SlackSelectMenuElement
+     */
+    public function confirm(SlackConfirm $confirm): SlackSelectMenuElement
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+
+    /**
+     * @param int $max_selected_items
+     * @return SlackSelectMenuElement
+     */
+    public function maxSelectedItems(int $max_selected_items): SlackSelectMenuElement
+    {
+        $this->max_selected_items = $max_selected_items;
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiStaticSelect.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiStaticSelect.php
@@ -7,7 +7,7 @@ namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElem
 use Kin29\SlackBlocksBuilder\Message\SlackOption;
 use Kin29\SlackBlocksBuilder\Message\SlackOptionGroup;
 
-class SlackMultiStaticSelect extends SlackSelectMenuElement
+class SlackMultiStaticSelect extends SlackMultiSelectMenuElement
 {
     protected ?string $type = 'multi_static_select';
 
@@ -19,9 +19,9 @@ class SlackMultiStaticSelect extends SlackSelectMenuElement
 
     /**
      * @param SlackOption[] $options
-     * @return SlackStaticSelect
+     * @return SlackMultiStaticSelect
      */
-    public function options(array $options): SlackStaticSelect
+    public function options(array $options): SlackMultiStaticSelect
     {
         foreach ($options as $option) {
             if (!$option instanceof SlackOption) {
@@ -36,9 +36,9 @@ class SlackMultiStaticSelect extends SlackSelectMenuElement
 
     /**
      * @param SlackOptionGroup[] $optionGroups
-     * @return SlackStaticSelect
+     * @return SlackMultiStaticSelect
      */
-    public function optionGroups(array $optionGroups): SlackStaticSelect
+    public function optionGroups(array $optionGroups): SlackMultiStaticSelect
     {
         foreach ($optionGroups as $optionGroup) {
             if (!$optionGroup instanceof SlackOptionGroup) {
@@ -53,9 +53,9 @@ class SlackMultiStaticSelect extends SlackSelectMenuElement
 
     /**
      * @param SlackOption[] $initialOptions
-     * @return SlackStaticSelect
+     * @return SlackMultiStaticSelect
      */
-    public function initialOptions(array $initialOptions): SlackStaticSelect
+    public function initialOptions(array $initialOptions): SlackMultiStaticSelect
     {
         foreach ($initialOptions as $initialOption) {
             if (!$initialOption instanceof SlackOption) {

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiStaticSelect.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiStaticSelect.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+use Kin29\SlackBlocksBuilder\Message\SlackOptionGroup;
+
+class SlackMultiStaticSelect extends SlackSelectMenuElement
+{
+    protected ?string $type = 'multi_static_select';
+
+    protected array $options;
+
+    protected array $option_groups;
+
+    protected array $initial_options;
+
+    /**
+     * @param SlackOption[] $options
+     * @return SlackStaticSelect
+     */
+    public function options(array $options): SlackStaticSelect
+    {
+        foreach ($options as $option) {
+            if (!$option instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->options[] = $option->payload();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param SlackOptionGroup[] $optionGroups
+     * @return SlackStaticSelect
+     */
+    public function optionGroups(array $optionGroups): SlackStaticSelect
+    {
+        foreach ($optionGroups as $optionGroup) {
+            if (!$optionGroup instanceof SlackOptionGroup) {
+                throw new \LogicException('Must hold only SlackOptionGroup instances.');
+            }
+
+            $this->option_groups[] = $optionGroup->payload();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param SlackOption[] $initialOptions
+     * @return SlackStaticSelect
+     */
+    public function initialOptions(array $initialOptions): SlackStaticSelect
+    {
+        foreach ($initialOptions as $initialOption) {
+            if (!$initialOption instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->initial_options[] = $initialOption->payload();
+        }
+
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiUserList.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiUserList.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement;
+
+class SlackMultiUserList extends SlackSelectMenuElement
+{
+    protected ?string $type = 'multi_users_select';
+
+    /**
+     * @var string[]
+     */
+    protected array $initial_users;
+
+    /**
+     * @param string[] $initial_users
+     * @return SlackMultiUserList
+     */
+    public function initialUsers(array $initial_users): SlackMultiUserList
+    {
+        $this->initial_users = $initial_users;
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiUserList.php
+++ b/src/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiUserList.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement;
 
-class SlackMultiUserList extends SlackSelectMenuElement
+class SlackMultiUserList extends SlackMultiSelectMenuElement
 {
     protected ?string $type = 'multi_users_select';
 

--- a/src/Message/SlackElement/SlackOverflowMenuElement.php
+++ b/src/Message/SlackElement/SlackOverflowMenuElement.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+
+class SlackOverflowMenuElement extends SlackElement
+{
+    protected ?string $type = 'overflow';
+
+    protected string $action_id;
+
+    protected array $options;
+
+    protected array $confirm;
+
+    /**
+     * @param string $action_id
+     * @return SlackOverflowMenuElement
+     */
+    public function actionId(string $action_id): SlackOverflowMenuElement
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param SlackOption[] $options
+     * @return SlackOverflowMenuElement
+     */
+    public function options(array $options): SlackOverflowMenuElement
+    {
+        foreach ($options as $option) {
+            if (!$option instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->options[] = $option->payload();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param SlackConfirm $confirm
+     * @return SlackOverflowMenuElement
+     */
+    public function confirm(SlackConfirm $confirm): SlackOverflowMenuElement
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackPlainTextInputElement.php
+++ b/src/Message/SlackElement/SlackPlainTextInputElement.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackDispatchActionConfiguration;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+
+class SlackPlainTextInputElement extends SlackElement
+{
+    protected ?string $type = 'plain_text_input';
+
+    protected string $action_id;
+
+    protected array $placeholder;
+
+    protected string $initial_value;
+
+    protected bool $multiline;
+
+    protected int $min_length;
+
+    protected int $max_length;
+
+    protected array $dispatch_action_config;
+
+    /**
+     * @param string $action_id
+     * @return SlackPlainTextInputElement
+     */
+    public function actionId(string $action_id): SlackPlainTextInputElement
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param SlackText $placeholder
+     * @return SlackPlainTextInputElement
+     */
+    public function placeholder(SlackText $placeholder): SlackPlainTextInputElement
+    {
+        $this->placeholder = $placeholder->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $initial_value
+     * @return SlackPlainTextInputElement
+     */
+    public function initialValue(string $initial_value): SlackPlainTextInputElement
+    {
+        $this->initial_value = $initial_value;
+        return $this;
+    }
+
+    /**
+     * @param bool $multiline
+     * @return SlackPlainTextInputElement
+     */
+    public function multiline(bool $multiline): SlackPlainTextInputElement
+    {
+        $this->multiline = $multiline;
+        return $this;
+    }
+
+    /**
+     * @param int $min_length
+     * @return SlackPlainTextInputElement
+     */
+    public function minLength(int $min_length): SlackPlainTextInputElement
+    {
+        $this->min_length = $min_length;
+        return $this;
+    }
+
+    /**
+     * @param int $max_length
+     * @return SlackPlainTextInputElement
+     */
+    public function maxLength(int $max_length): SlackPlainTextInputElement
+    {
+        $this->max_length = $max_length;
+        return $this;
+    }
+
+    /**
+     * @param SlackDispatchActionConfiguration $dispatch_action_config
+     * @return SlackPlainTextInputElement
+     */
+    public function dispatchActionConfig(SlackDispatchActionConfiguration $dispatch_action_config): SlackPlainTextInputElement
+    {
+        $this->dispatch_action_config = $dispatch_action_config->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackRadioButtonGroupElement.php
+++ b/src/Message/SlackElement/SlackRadioButtonGroupElement.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+
+class SlackRadioButtonGroupElement extends SlackElement
+{
+    protected ?string $type = 'radio_buttons';
+
+    protected string $action_id;
+
+    protected array $options;
+
+    protected array $initial_option;
+
+    protected array $confirm;
+
+    /**
+     * @param string $action_id
+     * @return SlackRadioButtonGroupElement
+     */
+    public function actionId(string $action_id): SlackRadioButtonGroupElement
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param SlackOption[] $options
+     * @return SlackRadioButtonGroupElement
+     */
+    public function options(array $options): SlackRadioButtonGroupElement
+    {
+        foreach ($options as $option) {
+            if (!$option instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->options[] = $option->payload();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param SlackOption $initial_option
+     * @return SlackRadioButtonGroupElement
+     */
+    public function initialOption(SlackOption $initial_option): SlackRadioButtonGroupElement
+    {
+        $this->initial_option = $initial_option->payload();
+        return $this;
+    }
+
+    /**
+     * @param SlackConfirm $confirm
+     * @return SlackRadioButtonGroupElement
+     */
+    public function confirm(SlackConfirm $confirm): SlackRadioButtonGroupElement
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackSelectMenuElement/SlackConversationsList.php
+++ b/src/Message/SlackElement/SlackSelectMenuElement/SlackConversationsList.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackFilter;
+
+class SlackConversationsList extends SlackSelectMenuElement
+{
+    protected ?string $type = 'conversations_select';
+
+    /**
+     * @var string[]
+     */
+    protected array $initial_conversations;
+
+    protected bool $default_to_current_conversation = false;
+
+    protected array $filter;
+
+    protected bool $response_url_enabled;
+
+
+    /**
+     * @param string[] $initial_conversations
+     * @return SlackConversationsList
+     */
+    public function initialConversations(array $initial_conversations): SlackConversationsList
+    {
+        $this->initial_conversations = $initial_conversations;
+        return $this;
+    }
+
+    /**
+     * @param bool $default_to_current_conversation
+     * @return SlackConversationsList
+     */
+    public function defaultToCurrentConversation(bool $default_to_current_conversation): SlackConversationsList
+    {
+        $this->default_to_current_conversation = $default_to_current_conversation;
+        return $this;
+    }
+
+    /**
+     * @param SlackFilter $filter
+     * @return SlackConversationsList
+     */
+    public function filter(SlackFilter $filter): SlackConversationsList
+    {
+        $this->filter = $filter->payload();
+        return $this;
+    }
+
+    /**
+     * @param bool $response_url_enabled
+     * @return SlackConversationsList
+     */
+    public function responseUrlEnabled(bool $response_url_enabled): SlackConversationsList
+    {
+        $this->response_url_enabled = $response_url_enabled;
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackSelectMenuElement/SlackExternalSelect.php
+++ b/src/Message/SlackElement/SlackSelectMenuElement/SlackExternalSelect.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+
+class SlackExternalSelect extends SlackSelectMenuElement
+{
+    protected ?string $type = 'external_select';
+
+    protected array $initial_options;
+
+    protected int $min_query_length;
+
+    /**
+     * @param int $min_query_length
+     * @return SlackExternalSelect
+     */
+    public function minQueryLength(int $min_query_length): SlackExternalSelect
+    {
+        $this->min_query_length = $min_query_length;
+        return $this;
+    }
+
+    /**
+     * @param SlackOption[] $initialOptions
+     * @return SlackExternalSelect
+     */
+    public function initialOptions(array $initialOptions): SlackExternalSelect
+    {
+        foreach ($initialOptions as $initialOption) {
+            if (!$initialOption instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->initial_options[] = $initialOption->payload();
+        }
+
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackSelectMenuElement/SlackPublicChannelsList.php
+++ b/src/Message/SlackElement/SlackSelectMenuElement/SlackPublicChannelsList.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+
+class SlackPublicChannelsList extends SlackSelectMenuElement
+{
+    protected ?string $type = 'channels_select';
+
+    protected string $initial_channel;
+
+    protected bool $response_url_enabled;
+
+    /**
+     * @param string $initial_channel
+     * @return SlackPublicChannelsList
+     */
+    public function initialChannels(string $initial_channel): SlackPublicChannelsList
+    {
+        $this->initial_channel = $initial_channel;
+        return $this;
+    }
+
+    /**
+     * @param bool $response_url_enabled
+     * @return SlackPublicChannelsList
+     */
+    public function responseUrlEnabled(bool $response_url_enabled): SlackPublicChannelsList
+    {
+        $this->response_url_enabled = $response_url_enabled;
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackSelectMenuElement/SlackSelectMenuElement.php
+++ b/src/Message/SlackElement/SlackSelectMenuElement/SlackSelectMenuElement.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackElement;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+
+class SlackSelectMenuElement extends SlackElement
+{
+    protected array $placeholder;
+
+    protected string $action_id;
+
+    protected array $confirm;
+
+    /**
+     * @param SlackText $placeholder
+     * @return SlackSelectMenuElement
+     */
+    public function placeholder(SlackText $placeholder): SlackSelectMenuElement
+    {
+        $this->placeholder = $placeholder->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $action_id
+     * @return SlackSelectMenuElement
+     */
+    public function actionId(string $action_id): SlackSelectMenuElement
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param SlackConfirm $confirm
+     * @return SlackSelectMenuElement
+     */
+    public function confirm(SlackConfirm $confirm): SlackSelectMenuElement
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackSelectMenuElement/SlackStaticSelect.php
+++ b/src/Message/SlackElement/SlackSelectMenuElement/SlackStaticSelect.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+use Kin29\SlackBlocksBuilder\Message\SlackOptionGroup;
+
+class SlackStaticSelect extends SlackSelectMenuElement
+{
+    protected ?string $type = 'static_select';
+
+    protected array $options;
+
+    protected array $option_groups;
+
+    protected array $initial_options;
+
+    /**
+     * @param SlackOption[] $options
+     * @return SlackStaticSelect
+     */
+    public function options(array $options): SlackStaticSelect
+    {
+        foreach ($options as $option) {
+            if (!$option instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->options[] = $option->payload();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param SlackOptionGroup[] $optionGroups
+     * @return SlackStaticSelect
+     */
+    public function optionGroups(array $optionGroups): SlackStaticSelect
+    {
+        foreach ($optionGroups as $optionGroup) {
+            if (!$optionGroup instanceof SlackOptionGroup) {
+                throw new \LogicException('Must hold only SlackOptionGroup instances.');
+            }
+
+            $this->option_groups[] = $optionGroup->payload();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param SlackOption[] $initialOptions
+     * @return SlackStaticSelect
+     */
+    public function initialOptions(array $initialOptions): SlackStaticSelect
+    {
+        foreach ($initialOptions as $initialOption) {
+            if (!$initialOption instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->initial_options[] = $initialOption->payload();
+        }
+
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackSelectMenuElement/SlackUserList.php
+++ b/src/Message/SlackElement/SlackSelectMenuElement/SlackUserList.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement;
+
+class SlackUserList extends SlackSelectMenuElement
+{
+    protected ?string $type = 'users_select';
+
+    /**
+     * @var string[]
+     */
+    protected array $initial_users;
+
+    /**
+     * @param string[] $initial_users
+     * @return SlackUserList
+     */
+    public function initialUsers(array $initial_users): SlackUserList
+    {
+        $this->initial_users = $initial_users;
+        return $this;
+    }
+}

--- a/src/Message/SlackElement/SlackTimePickerElement.php
+++ b/src/Message/SlackElement/SlackTimePickerElement.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackConfirm;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+
+class SlackTimePickerElement extends SlackElement
+{
+    protected ?string $type = 'timepicker';
+
+    protected string $action_id;
+
+    protected array $placeholder;
+
+    protected string $initial_time;
+
+    protected array $confirm;
+
+    /**
+     * @param string $action_id
+     * @return SlackTimePickerElement
+     */
+    public function actionId(string $action_id): SlackTimePickerElement
+    {
+        $this->action_id = $action_id;
+        return $this;
+    }
+
+    /**
+     * @param SlackText $placeholder
+     * @return SlackTimePickerElement
+     */
+    public function placeholder(SlackText $placeholder): SlackTimePickerElement
+    {
+        $this->placeholder = $placeholder->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $initial_time
+     * @return SlackTimePickerElement
+     */
+    public function initialTime(string $initial_time): SlackTimePickerElement
+    {
+        $this->initial_time = $initial_time;
+        return $this;
+    }
+
+    /**
+     * @param SlackConfirm $confirm
+     * @return SlackTimePickerElement
+     */
+    public function confirm(SlackConfirm $confirm): SlackTimePickerElement
+    {
+        $this->confirm = $confirm->payload();
+        return $this;
+    }
+}

--- a/src/Message/SlackFilter.php
+++ b/src/Message/SlackFilter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message;
+
+class SlackFilter extends AbstractSlackMessage
+{
+    /**
+     * @var string[]
+     */
+    protected array $include;
+
+    protected bool $exclude_external_shared_channels;
+
+    protected bool $exclude_bot_users;
+
+    /**
+     * @param string[] $include
+     * @return SlackFilter
+     */
+    public function include(array $include): SlackFilter
+    {
+        $this->include = $include;
+        return $this;
+    }
+
+    /**
+     * @param bool $exclude_external_shared_channels
+     * @return SlackFilter
+     */
+    public function excludeExternalSharedChannels(bool $exclude_external_shared_channels): SlackFilter
+    {
+        $this->exclude_external_shared_channels = $exclude_external_shared_channels;
+        return $this;
+    }
+
+    /**
+     * @param bool $exclude_bot_users
+     * @return SlackFilter
+     */
+    public function excludeBotUsers(bool $exclude_bot_users): SlackFilter
+    {
+        $this->exclude_bot_users = $exclude_bot_users;
+        return $this;
+    }
+}

--- a/src/Message/SlackOption.php
+++ b/src/Message/SlackOption.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message;
+
+class SlackOption extends AbstractSlackMessage
+{
+    protected array $text;
+
+    protected string $value;
+
+    protected array $description;
+
+    protected string $url;
+
+    /**
+     * @param SlackText $text
+     * @return SlackOption
+     */
+    public function text(SlackText $text): SlackOption
+    {
+        $this->text = $text->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $value
+     * @return SlackOption
+     */
+    public function value(string $value): SlackOption
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * @param SlackText $description
+     * @return SlackOption
+     */
+    public function description(SlackText $description): SlackOption
+    {
+        $this->description = $description->payload();
+        return $this;
+    }
+
+    /**
+     * @param string $url
+     * @return SlackOption
+     */
+    public function url(string $url): SlackOption
+    {
+        $this->url = $url;
+        return $this;
+    }
+}

--- a/src/Message/SlackOptionGroup.php
+++ b/src/Message/SlackOptionGroup.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Message;
+
+class SlackOptionGroup extends AbstractSlackMessage
+{
+    protected array $label;
+
+    protected array $options;
+
+    /**
+     * @param SlackText $label
+     * @return SlackOptionGroup
+     */
+    public function label(SlackText $label): SlackOptionGroup
+    {
+        $this->label = $label->payload();
+        return $this;
+    }
+
+    /**
+     * @param SlackOption[] $options
+     * @return SlackOptionGroup
+     */
+    public function options(array $options): SlackOptionGroup
+    {
+        foreach ($options as $option) {
+            if (!$option instanceof SlackOption) {
+                throw new \LogicException('Must hold only SlackOption instances.');
+            }
+
+            $this->options[] = $option->payload();
+        }
+
+        return $this;
+    }
+}

--- a/tests/Message/SlackElement/SlackButtonElementTest.php
+++ b/tests/Message/SlackElement/SlackButtonElementTest.php
@@ -1,8 +1,11 @@
 <?php
 
-namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement;
 
 use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackButtonElement;
 use Kin29\SlackBlocksBuilder\Message\SlackText;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Message/SlackElement/SlackButtonElementTest.php
+++ b/tests/Message/SlackElement/SlackButtonElementTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackMessage;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackButtonElementTest extends TestCase
+{
+    public function test(): void
+    {
+        $buttonElement = (new SlackButtonElement())
+            ->text(
+                (new SlackText())
+                    ->type('plain_text')
+                    ->text('Hi!')
+                    ->emoji()
+            );
+
+        $expected = [
+            "element" => [
+                "type" => "button",
+                "text" => [
+                    "type" => "plain_text",
+                    "text" => "Hi!",
+                    "emoji" => true,
+                ]
+            ]
+        ];
+
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())->element($buttonElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackButtonElementTest.php
+++ b/tests/Message/SlackElement/SlackButtonElementTest.php
@@ -3,7 +3,6 @@
 namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
 
 use Kin29\SlackBlocksBuilder\Message\SlackBlock;
-use Kin29\SlackBlocksBuilder\Message\SlackMessage;
 use Kin29\SlackBlocksBuilder\Message\SlackText;
 use PHPUnit\Framework\TestCase;
 
@@ -15,18 +14,25 @@ class SlackButtonElementTest extends TestCase
             ->text(
                 (new SlackText())
                     ->type('plain_text')
-                    ->text('Hi!')
-                    ->emoji()
-            );
+                    ->text('Click Me')
+            )
+            ->value('click_me_123')
+            ->actionId('button')
+            ->style("primary")
+            ->url("https://api.slack.com/block-kit")
+        ;
 
         $expected = [
             "element" => [
                 "type" => "button",
                 "text" => [
                     "type" => "plain_text",
-                    "text" => "Hi!",
-                    "emoji" => true,
-                ]
+                    "text" => "Click Me",
+                ],
+                "action_id" => "button",
+                "url" => "https://api.slack.com/block-kit",
+                "value" => "click_me_123",
+                "style" => "primary",
             ]
         ];
 

--- a/tests/Message/SlackElement/SlackCheckBoxGroupsTest.php
+++ b/tests/Message/SlackElement/SlackCheckBoxGroupsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackCheckBoxGroupsTest extends TestCase
+{
+    public function test(): void
+    {
+        $checkboxElement = (new SlackCheckBoxGroups())
+            ->actionId('this_is_an_action_id')
+            ->initialOptions([
+                (new SlackOption())
+                    ->value('A1')
+                    ->text(
+                        (new SlackText())
+                            ->type('plain_text')
+                            ->text('Checkbox 1'))
+            ])
+            ->options([
+                (new SlackOption())
+                    ->value('A1')
+                    ->text(
+                        (new SlackText())
+                            ->type('plain_text')
+                            ->text('Checkbox 1')),
+                (new SlackOption())
+                    ->value('A2')
+                    ->text(
+                        (new SlackText())
+                            ->type('plain_text')
+                            ->text('Checkbox 2'))
+            ]);
+
+        $expected = [
+            "type" => "section",
+            "text" => [
+                "type" => "plain_text",
+                "text" => "Check out these charming checkboxes",
+            ],
+            "accessory" => [
+                "type" => "checkboxes",
+                "action_id" => "this_is_an_action_id",
+                "options" => [
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "Checkbox 1",
+                        ],
+                        "value" => "A1",
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "Checkbox 2",
+                        ],
+                        "value" => "A2",
+                    ],
+                ],
+                "initial_options" => [
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "Checkbox 1",
+                        ],
+                        "value" => "A1",
+                    ],
+                ],
+            ]
+        ];
+
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->text(
+                    (new SlackText())
+                        ->type('plain_text')
+                        ->text('Check out these charming checkboxes'))
+                ->accessory($checkboxElement)
+            );
+    }
+}

--- a/tests/Message/SlackElement/SlackDatePickerElementTest.php
+++ b/tests/Message/SlackElement/SlackDatePickerElementTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackDatePickerElementTest extends TestCase
+{
+    public function test(): void
+    {
+        $datePickerElement = (new SlackDatePickerElement())
+            ->actionId('datepicker123')
+            ->initialDate("1990-04-28")
+            ->placeholder(
+                (new SlackText())
+                    ->type('plain_text')
+                    ->text('Select a date')
+            )
+        ;
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section1234",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick a date for the deadline.",
+            ],
+            "accessory" => [
+                "type" => "datepicker",
+                "action_id" => "datepicker123",
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select a date",
+                ],
+                "initial_date" => "1990-04-28",
+            ]
+        ];
+
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section1234')
+                ->text(
+                    (new SlackText())
+                        ->type('mrkdwn')
+                        ->text('Pick a date for the deadline.')
+                )
+                ->accessory($datePickerElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackImageElementTest.php
+++ b/tests/Message/SlackElement/SlackImageElementTest.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+declare(strict_types=1);
 
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackImageElement;
 use PHPUnit\Framework\TestCase;
 
 class SlackImageElementTest extends TestCase

--- a/tests/Message/SlackElement/SlackImageElementTest.php
+++ b/tests/Message/SlackElement/SlackImageElementTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kin29\SlackBlocksBuilder\Message\SlackElement;
+
+use PHPUnit\Framework\TestCase;
+
+class SlackImageElementTest extends TestCase
+{
+    public function test(): void
+    {
+        $expected = [
+            "type" => "image",
+            "image_url" => "http://placekitten.com/700/500",
+            "alt_text" => "Multiple cute kittens",
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackImageElement())
+                ->altText('Multiple cute kittens')
+                ->imageUrl('http://placekitten.com/700/500')
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiConversationsListTest.php
+++ b/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiConversationsListTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement\SlackMultiConversationsList;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackMultiConversationsListTest extends TestCase
+{
+    public function test(): void
+    {
+        $multiConversationsListElement = (new SlackMultiConversationsList())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select conversations'))
+        ;
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick conversations from the list"
+            ],
+            "accessory" => [
+                "type" => "multi_conversations_select",
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select conversations"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())->type('mrkdwn')->text('Pick conversations from the list'))
+                ->accessory($multiConversationsListElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiExternalSelectTest.php
+++ b/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiExternalSelectTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement\SlackMultiExternalSelect;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackMultiExternalSelectTest extends TestCase
+{
+    public function test(): void
+    {
+        $multiEternalSelectElement = (new SlackMultiExternalSelect())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select items'))
+            ->minQueryLength(3);
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick items from the list"
+            ],
+            "accessory" => [
+                "type" => "multi_external_select",
+                "min_query_length" => 3,
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select items"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())->type('mrkdwn')->text('Pick items from the list'))
+                ->accessory($multiEternalSelectElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiPublicChannelsListTest.php
+++ b/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiPublicChannelsListTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement\SlackMultiPublicChannelsList;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackMultiPublicChannelsListTest extends TestCase
+{
+    public function test(): void
+    {
+        $multiPublicChannelsListElement = (new SlackMultiPublicChannelsList())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select channels'))
+        ;
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick channels from the list"
+            ],
+            "accessory" => [
+                "type" => "multi_channels_select",
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select channels"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())->type('mrkdwn')->text('Pick channels from the list'))
+                ->accessory($multiPublicChannelsListElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiStaticSelectTest.php
+++ b/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiStaticSelectTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement\SlackMultiStaticSelect;
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackMultiStaticSelectTest extends TestCase
+{
+    public function test(): void
+    {
+        $multiStaticElement = (new SlackMultiStaticSelect())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())
+                ->type('plain_text')
+                ->text('Select items'))
+            ->options([
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-0'),
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-1'),
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-2'),
+            ]);
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick items from the list"
+            ],
+            "accessory" => [
+                "type" => "multi_static_select",
+                "options" => [
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-0"
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-1"
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-2"
+                    ],
+                ],
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select items"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())
+                    ->type('mrkdwn')
+                    ->text('Pick items from the list'))
+                ->accessory($multiStaticElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiUserListTest.php
+++ b/tests/Message/SlackElement/SlackMultiSelectMenuElement/SlackMultiUserListTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackMultiSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackMultiSelectMenuElement\SlackMultiUserList;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackMultiUserListTest extends TestCase
+{
+    public function test(): void
+    {
+        $multiUserListElement = (new SlackMultiUserList())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select users'))
+        ;
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick users from the list"
+            ],
+            "accessory" => [
+                "type" => "multi_users_select",
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select users"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())->type('mrkdwn')->text('Pick users from the list'))
+                ->accessory($multiUserListElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackOverflowMenuElementTest.php
+++ b/tests/Message/SlackElement/SlackOverflowMenuElementTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackOverflowMenuElement;
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackOverflowMenuElementTest extends TestCase
+{
+    public function test(): void
+    {
+        $overFlowMenuElement = (new SlackOverflowMenuElement())
+            ->actionId('overflow')
+            ->options([
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-0'),
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-1'),
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-2'),
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-3'),
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-4'),
+            ])
+        ;
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section 890",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "This is a section block with an overflow menu."
+            ],
+            "accessory" => [
+                "type" => "overflow",
+                "action_id" => "overflow",
+                "options" => [
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-0",
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-1",
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-2",
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-3",
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-4",
+                    ],
+                ],
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section 890')
+                ->text((new SlackText())->type('mrkdwn')->text('This is a section block with an overflow menu.'))
+                ->accessory($overFlowMenuElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackPlainTextInputElementTest.php
+++ b/tests/Message/SlackElement/SlackPlainTextInputElementTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackPlainTextInputElement;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackPlainTextInputElementTest extends TestCase
+{
+    public function test(): void
+    {
+        $plainTextInputElement = (new SlackPlainTextInputElement())
+            ->actionId('plain_input')
+            ->placeholder((new SlackText())->type('plain_text')->text('Enter some plain text'))
+        ;
+
+        $expected = [
+            "type" => "input",
+            "block_id" => "input123",
+            "text" => [
+                "type" => "plain_text",
+                "text" => "Label of input"
+            ],
+            "element" => [
+                "type" => "plain_text_input",
+                "action_id" => "plain_input",
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Enter some plain text"
+                ],
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('input')
+                ->blockId('input123')
+                ->text((new SlackText())->type('plain_text')->text('Label of input'))
+                ->element($plainTextInputElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackRadioButtonGroupElementTest.php
+++ b/tests/Message/SlackElement/SlackRadioButtonGroupElementTest.php
@@ -5,87 +5,72 @@ declare(strict_types=1);
 namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement;
 
 use Kin29\SlackBlocksBuilder\Message\SlackBlock;
-use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackCheckBoxGroups;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackRadioButtonGroupElement;
 use Kin29\SlackBlocksBuilder\Message\SlackOption;
 use Kin29\SlackBlocksBuilder\Message\SlackText;
 use PHPUnit\Framework\TestCase;
 
-class SlackCheckBoxGroupsTest extends TestCase
+class SlackRadioButtonGroupElementTest extends TestCase
 {
     public function test(): void
     {
-        $checkboxElement = (new SlackCheckBoxGroups())
+        $radioButtonGroupElement = (new SlackRadioButtonGroupElement())
             ->actionId('this_is_an_action_id')
-            ->initialOptions([
+            ->initialOption(
                 (new SlackOption())
                     ->value('A1')
-                    ->text(
-                        (new SlackText())
-                            ->type('plain_text')
-                            ->text('Checkbox 1'))
-            ])
+                    ->text((new SlackText())->type('plain_text')->text('Radio 1')))
             ->options([
                 (new SlackOption())
                     ->value('A1')
-                    ->text(
-                        (new SlackText())
-                            ->type('plain_text')
-                            ->text('Checkbox 1')),
+                    ->text((new SlackText())->type('plain_text')->text('Radio 1')),
                 (new SlackOption())
                     ->value('A2')
-                    ->text(
-                        (new SlackText())
-                            ->type('plain_text')
-                            ->text('Checkbox 2'))
-            ]);
+                    ->text((new SlackText())->type('plain_text')->text('Radio 2'))
+            ])
+        ;
 
         $expected = [
             "type" => "section",
             "text" => [
                 "type" => "plain_text",
-                "text" => "Check out these charming checkboxes",
+                "text" => "Check out these rad radio buttons"
             ],
             "accessory" => [
-                "type" => "checkboxes",
+                "type" => "radio_buttons",
                 "action_id" => "this_is_an_action_id",
                 "options" => [
                     [
                         "text" => [
                             "type" => "plain_text",
-                            "text" => "Checkbox 1",
+                            "text" => "Radio 1"
                         ],
                         "value" => "A1",
                     ],
                     [
                         "text" => [
                             "type" => "plain_text",
-                            "text" => "Checkbox 2",
+                            "text" => "Radio 2"
                         ],
                         "value" => "A2",
                     ],
                 ],
-                "initial_options" => [
-                    [
-                        "text" => [
-                            "type" => "plain_text",
-                            "text" => "Checkbox 1",
-                        ],
-                        "value" => "A1",
+                "initial_option" => [
+                    "text" => [
+                        "type" => "plain_text",
+                        "text" => "Radio 1"
                     ],
+                    "value" => "A1",
                 ],
             ]
         ];
-
 
         $this->assertEquals(
             json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
             (string)(new SlackBlock())
                 ->type('section')
-                ->text(
-                    (new SlackText())
-                        ->type('plain_text')
-                        ->text('Check out these charming checkboxes'))
-                ->accessory($checkboxElement)
-            );
+                ->text((new SlackText())->type('plain_text')->text('Check out these rad radio buttons'))
+                ->accessory($radioButtonGroupElement)
+        );
     }
 }

--- a/tests/Message/SlackElement/SlackSelectMenuElement/SlackConversationsListTest.php
+++ b/tests/Message/SlackElement/SlackSelectMenuElement/SlackConversationsListTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement\SlackConversationsList;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackConversationsListTest extends TestCase
+{
+    public function test(): void
+    {
+        $conversationsListElement = (new SlackConversationsList())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select an item'))
+        ;
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick a conversation from the dropdown list"
+            ],
+            "accessory" => [
+                "type" => "conversations_select",
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select an item"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())->type('mrkdwn')->text('Pick a conversation from the dropdown list'))
+                ->accessory($conversationsListElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackSelectMenuElement/SlackExternalSelectTest.php
+++ b/tests/Message/SlackElement/SlackSelectMenuElement/SlackExternalSelectTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement\SlackExternalSelect;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackExternalSelectTest extends TestCase
+{
+    public function test(): void
+    {
+        $eternalSelectElement = (new SlackExternalSelect())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select an item'))
+            ->minQueryLength(3);
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick an item from the dropdown list"
+            ],
+            "accessory" => [
+                "type" => "external_select",
+                "min_query_length" => 3,
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select an item"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())->type('mrkdwn')->text('Pick an item from the dropdown list'))
+                ->accessory($eternalSelectElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackSelectMenuElement/SlackPublicChannelsListTest.php
+++ b/tests/Message/SlackElement/SlackSelectMenuElement/SlackPublicChannelsListTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement\SlackPublicChannelsList;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackPublicChannelsListTest extends TestCase
+{
+    public function test(): void
+    {
+        $publicChannelsListElement = (new SlackPublicChannelsList())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select an item'))
+        ;
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick a channel from the dropdown list"
+            ],
+            "accessory" => [
+                "type" => "channels_select",
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select an item"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())->type('mrkdwn')->text('Pick a channel from the dropdown list'))
+                ->accessory($publicChannelsListElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackSelectMenuElement/SlackStaticSelectTest.php
+++ b/tests/Message/SlackElement/SlackSelectMenuElement/SlackStaticSelectTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement\SlackStaticSelect;
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackStaticSelectTest extends TestCase
+{
+    public function test(): void
+    {
+        $staticElement = (new SlackStaticSelect())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())
+                ->type('plain_text')
+                ->text('Select an item'))
+            ->options([
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-0'),
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-1'),
+                (new SlackOption())
+                    ->text((new SlackText())->type('plain_text')->text('*this is plain_text text*'))
+                    ->value('value-2'),
+            ]);
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick an item from the dropdown list"
+            ],
+            "accessory" => [
+                "type" => "static_select",
+                "options" => [
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-0"
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-1"
+                    ],
+                    [
+                        "text" => [
+                            "type" => "plain_text",
+                            "text" => "*this is plain_text text*"
+                        ],
+                        "value" => "value-2"
+                    ],
+                ],
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select an item"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())
+                    ->type('mrkdwn')
+                    ->text('Pick an item from the dropdown list'))
+                ->accessory($staticElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackSelectMenuElement/SlackUserListTest.php
+++ b/tests/Message/SlackElement/SlackSelectMenuElement/SlackUserListTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement\SlackSelectMenuElement;
+
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackSelectMenuElement\SlackUserList;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
+use PHPUnit\Framework\TestCase;
+
+class SlackUserListTest extends TestCase
+{
+    public function test(): void
+    {
+        $userListElement = (new SlackUserList())
+            ->actionId('text1234')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select an item'))
+        ;
+
+        $expected = [
+            "type" => "section",
+            "block_id" => "section678",
+            "text" => [
+                "type" => "mrkdwn",
+                "text" => "Pick a user from the dropdown list"
+            ],
+            "accessory" => [
+                "type" => "users_select",
+                "placeholder" => [
+                    "type" => "plain_text",
+                    "text" => "Select an item"
+                ],
+                "action_id" => "text1234",
+            ]
+        ];
+
+        $this->assertEquals(
+            json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            (string)(new SlackBlock())
+                ->type('section')
+                ->blockId('section678')
+                ->text((new SlackText())->type('mrkdwn')->text('Pick a user from the dropdown list'))
+                ->accessory($userListElement)
+        );
+    }
+}

--- a/tests/Message/SlackElement/SlackTimePickerElementTest.php
+++ b/tests/Message/SlackElement/SlackTimePickerElementTest.php
@@ -6,52 +6,46 @@ namespace Kin29\SlackBlocksBuilder\Tests\Message\SlackElement;
 
 use Kin29\SlackBlocksBuilder\Message\SlackBlock;
 use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackDatePickerElement;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackRadioButtonGroupElement;
+use Kin29\SlackBlocksBuilder\Message\SlackElement\SlackTimePickerElement;
+use Kin29\SlackBlocksBuilder\Message\SlackOption;
 use Kin29\SlackBlocksBuilder\Message\SlackText;
 use PHPUnit\Framework\TestCase;
 
-class SlackDatePickerElementTest extends TestCase
+class SlackTimePickerElementTest extends TestCase
 {
     public function test(): void
     {
-        $datePickerElement = (new SlackDatePickerElement())
-            ->actionId('datepicker123')
-            ->initialDate("1990-04-28")
-            ->placeholder(
-                (new SlackText())
-                    ->type('plain_text')
-                    ->text('Select a date')
-            )
+        $datePickerElement = (new SlackTimePickerElement())
+            ->actionId('timepicker123')
+            ->placeholder((new SlackText())->type('plain_text')->text('Select a time'))
+            ->initialTime('11:40')
         ;
 
         $expected = [
             "type" => "section",
             "block_id" => "section1234",
             "text" => [
-                "type" => "mrkdwn",
-                "text" => "Pick a date for the deadline.",
+                "type" => "mkdwn",
+                "text" => "Pick a date for the deadline."
             ],
             "accessory" => [
-                "type" => "datepicker",
-                "action_id" => "datepicker123",
+                "type" => "timepicker",
+                "action_id" => "timepicker123",
                 "placeholder" => [
                     "type" => "plain_text",
-                    "text" => "Select a date",
+                    "text" => "Select a time"
                 ],
-                "initial_date" => "1990-04-28",
+                "initial_time" => "11:40"
             ]
         ];
-
 
         $this->assertEquals(
             json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
             (string)(new SlackBlock())
                 ->type('section')
                 ->blockId('section1234')
-                ->text(
-                    (new SlackText())
-                        ->type('mrkdwn')
-                        ->text('Pick a date for the deadline.')
-                )
+                ->text((new SlackText())->type('mkdwn')->text('Pick a date for the deadline.'))
                 ->accessory($datePickerElement)
         );
     }

--- a/tests/Message/SlackMessageTest.php
+++ b/tests/Message/SlackMessageTest.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace Kin29\SlackBlocksBuilder\Message;
+namespace Kin29\SlackBlocksBuilder\Tests\Message;
 
+use Kin29\SlackBlocksBuilder\Message\SlackBlock;
+use Kin29\SlackBlocksBuilder\Message\SlackMessage;
+use Kin29\SlackBlocksBuilder\Message\SlackText;
 use PHPUnit\Framework\TestCase;
 
 class SlackMessageTest extends TestCase

--- a/tests/Message/SlackMessageTest.php
+++ b/tests/Message/SlackMessageTest.php
@@ -8,16 +8,14 @@ class SlackMessageTest extends TestCase
 {
     public function testBuildMessage()
     {
-        $text = (new SlackText())
-            ->type('mrkdwn')
-            ->text('Hello!');
-
         $block = (new SlackBlock())
             ->type('section')
-            ->text($text);
+            ->text(
+                (new SlackText())
+                    ->type('mrkdwn')
+                    ->text('Hello!')
+            );
 
-        $message = new SlackMessage();
-        $message->blocks([$block, $block]);
 
         $expected = [
             "blocks" => [
@@ -40,7 +38,7 @@ class SlackMessageTest extends TestCase
 
         $this->assertEquals(
             json_encode($expected, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
-            (string)$message
+            (new SlackMessage())->blocks([$block, $block])
         );
     }
 


### PR DESCRIPTION
 - [Block elements](https://api.slack.com/reference/block-kit/block-elements)をsrc/Message/SlackElement/にまとめて作成
- ↑にともない、Option,Option group,Dispatch action configuration,Filter for conversation listsのオブジェクトも追加
- SlackBlock.phpに$elementsはあったが、$elementはなかったので追加